### PR TITLE
Add gz as application/octet-stream

### DIFF
--- a/types/mime.types
+++ b/types/mime.types
@@ -151,7 +151,7 @@ application/mxf					mxf
 # application/nss
 # application/ocsp-request
 # application/ocsp-response
-application/octet-stream	bin dms lrf mar so dist distz pkg bpk dump elc deploy
+application/octet-stream	bin dms lrf mar so dist distz pkg bpk dump elc deploy gz
 application/oda					oda
 application/oebps-package+xml			opf
 application/ogg					ogx

--- a/types/mime.types
+++ b/types/mime.types
@@ -151,7 +151,7 @@ application/mxf					mxf
 # application/nss
 # application/ocsp-request
 # application/ocsp-response
-application/octet-stream	bin dms lrf mar so dist distz pkg bpk dump elc deploy gz
+application/octet-stream	bin dms lrf mar so dist distz pkg bpk dump elc deploy
 application/oda					oda
 application/oebps-package+xml			opf
 application/ogg					ogx

--- a/types/node.types
+++ b/types/node.types
@@ -80,3 +80,9 @@ font/opentype  otf
 # Why: The entire file is a single JSON object, and the Google CDN already serves this MIME type: http://stackoverflow.com/questions/19911929/what-mime-type-should-i-use-for-source-map-files
 # Added by: zertosh
 application/json  map
+
+# What: JAR Pack200 files - http://docs.oracle.com/javase/tutorial/deployment/deploymentInDepth/reducingDownloadTime.html
+# Why:	Java browser plugin throws ClassNotFoundException on files loaded
+#		with incorrect headers
+# Added by: Andras Stracz
+application/octet-stream gz

--- a/types/node.types
+++ b/types/node.types
@@ -80,9 +80,3 @@ font/opentype  otf
 # Why: The entire file is a single JSON object, and the Google CDN already serves this MIME type: http://stackoverflow.com/questions/19911929/what-mime-type-should-i-use-for-source-map-files
 # Added by: zertosh
 application/json  map
-
-# What: JAR Pack200 files - http://docs.oracle.com/javase/tutorial/deployment/deploymentInDepth/reducingDownloadTime.html
-# Why:	Java browser plugin throws ClassNotFoundException on files loaded
-#		with incorrect headers
-# Added by: Andras Stracz
-application/octet-stream gz

--- a/types/node.types
+++ b/types/node.types
@@ -80,3 +80,9 @@ font/opentype  otf
 # Why: The entire file is a single JSON object, and the Google CDN already serves this MIME type: http://stackoverflow.com/questions/19911929/what-mime-type-should-i-use-for-source-map-files
 # Added by: zertosh
 application/json  map
+
+# What: JAR Pack200 files - http://docs.oracle.com/javase/tutorial/deployment/deploymentInDepth/reducingDownloadTime.html
+# Why:  Java browser plugin throws ClassNotFoundException on files loaded
+#       with incorrect headers
+# Added by: Andras Stracz
+application/octet-stream  gz


### PR DESCRIPTION
What: jar pack200 files - http://docs.oracle.com/javase/tutorial/deployment/deploymentInDepth/reducingDownloadTime.html
Why: java browser plugin throws classnotfoundexception on the default content-type headers
Who needs it? Probably not that many people, but this is where the patch belongs and since node-mime is used through karma-runner, it'd be difficult to maintain a mime.define() in its code on all our CI servers.