### PR TITLE
Add simple cli

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+var mime = require('./mime.js');
+var file = process.argv[2];
+var type = mime.lookup(file);
+
+process.stdout.write(type + '\n');
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "test": "node test.js"
   },
+  "bin": {
+    "mime": "cli.js"
+  },
   "contributors": [
     {
       "name": "Benjamin Thomas",


### PR DESCRIPTION
Enables `mime path/to/file`, outputs the type on stdout. I find it more accurate than `file(1)`, which gives e.g. `blah.js` as `text/plain` (and who wants to maintain custom magic files?)