### PR TITLE
Add support of HJSON

### DIFF
--- a/types/node.types
+++ b/types/node.types
@@ -96,3 +96,8 @@ application/font-woff2  woff2
 # Why: Easier on the eye than XML or even JSON - https://en.wikipedia.org/wiki/YAML
 # Added by: chrisveness
 text/yaml yaml yml
+
+# What: HJSON - http://laktak.github.io/hjson/
+# Why: This is a direct superset of JSON. Sure to catch on.
+# Added by: howardroark
+text/hjson hjson


### PR DESCRIPTION
I would like to use this tool in a project of mine.  I am allowing users to supply YAML, JSON and HJSON as their data.  The idea is to use a mime type to identify how to parse the data.  HJSON is really new, but it is a smart idea.  JSON has become a ubiquitous method for configuring projects and HJSON makes it a little easier for humans to edit without the need to deal with whitespace.  This makes it easy to edit with any tool.