### PR TITLE
Rename node -> nodejs

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env nodejs
 
 var mime = require('./mime.js');
 var file = process.argv[2];


### PR DESCRIPTION
There is a naming conflict with the node package (Amateur Packet Radio Node Program), and the nodejs binary has been renamed from node to nodejs.
