### PR TITLE
Allow types.json to be packaged

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
       "email": "benjamin@benjaminthomas.org"
     }
   ],
-  "dependencies": {
-    "mime-db": "^1.2.0"
-  },
   "description": "A comprehensive library for mime-type mapping",
   "licenses": [
     {
@@ -27,11 +24,14 @@
       "url": "https://raw.github.com/broofa/node-mime/master/LICENSE"
     }
   ],
+  "dependencies": {},
+  "devDependencies": {
+    "mime-db": "^1.2.0"
+  },
   "scripts": {
-    "install": "node build/build.js > types.json",
+    "prepublish": "node build/build.js > types.json",
     "test": "node build/test.js"
   },
-  "devDependencies": {},
   "keywords": [
     "util",
     "mime"


### PR DESCRIPTION
Npm docs call install hooks an anti-pattern; one of the reasons is that they prevent a package from being bundled and subsequently installed on another system:
```
$ cat package.json
{
  "author": {
    "name": "Simon Ratner"
  },
  "dependencies": {
      "mime": "^1.3.0"
  },
  "bundleDependencies": [
      "mime"
  ],
  "name": "mime-test",
  "version": "0.0.1",
  "scripts": {
      "test": "node 'require(\"mime\")'"
  }
}

$ npm pack
mime-test-0.0.1.tgz

$ npm install --prefix tmp --production --no-rebuild-bundle mime-test-0.0.1.tgz
npm WARN package.json mime-test@0.0.1 No description
npm WARN package.json mime-test@0.0.1 No repository field.
mime-test@0.0.1 tmp/node_modules/mime-test

# Note that the install hook is not run, due to no-rebuild flag

$ (cd tmp/node_modules/mime-test && npm test)

> mime-test@0.0.1 test /Users/simon.ratner/Code/node-mime-test/tmp/node_modules/mime-test
> node ./test.js

module.js:340
    throw err;
          ^
Error: Cannot find module './types.json'
```

This change uses a prepublish hook to generate types.json, and adds an empty .npmignore to ensure that types.json is packaged in the bundle (otherwise, npm uses .gitignore which excludes this file).