### PR TITLE
Add 'glob' function to expand mime patterns.

### DIFF
--- a/build/test.js
+++ b/build/test.js
@@ -38,6 +38,15 @@ assert.equal('html', mime.extension('text/Html;charset=UTF-8'));
 assert.equal(undefined, mime.extension('unrecognized'));
 
 //
+// Test glob
+//
+
+assert.deepEqual(['application/octet-stream'], mime.glob('*/*'));
+assert.notEqual(mime.glob('application/*').indexOf('application/json'), -1);
+assert.deepEqual([], mime.glob('qwerty/*'));
+assert.deepEqual(['qwerty/qwerty'], mime.glob('qwerty/qwerty'));
+
+//
 // Test node.types lookups
 //
 

--- a/mime.js
+++ b/mime.js
@@ -80,6 +80,27 @@ Mime.prototype.extension = function(mimeType) {
   return this.extensions[type];
 };
 
+/**
+ * Return all MIME types which matching a pattern
+ */
+Mime.prototype.glob = function (pattern) {
+  if (pattern == '*/*')
+    return ['application/octet-stream'];
+
+  var slashIdx = pattern.indexOf('/');
+  if (slashIdx == -1 || pattern.slice(slashIdx + 1) !== "*")
+    return [pattern];
+
+  var prefix = pattern.slice(0,slashIdx+1);
+  var result = [];
+  var keys = Object.keys(this.extensions);
+  keys.forEach(function (name) {
+    if (name.slice(0, slashIdx+1) === prefix)
+      result.push(name);
+  })
+  return result;
+}
+
 // Default instance
 var mime = new Mime();
 


### PR DESCRIPTION
For example "\*/\*", "video/\*", "audio/\*", ..
This is documented by this [spec](http://tools.ietf.org/html/rfc2616#section-14.1)