### PR TITLE
Expose full list of extensions for a mimetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ mime.extension('text/html');                 // => 'html'
 mime.extension('application/octet-stream');  // => 'bin'
 ```
 
+### mime.extensions(type)
+Get all extensions for `type`
+
+```js
+mime.extensions('text/html');                 // => ['html', 'htm' ]
+mime.extensions('application/x-latex');       // => ['latex']
+mime.extensions('image/jpeg');                // => ["jpeg","jpg","jpe"]
+```
+
 ### mime.charsets.lookup()
 
 Map mime-type to charset
@@ -78,6 +87,12 @@ The first entry in the extensions array is returned by `mime.extension()`. E.g.
 
 ```js
 mime.extension('text/x-some-format'); // => 'x-sf'
+```
+
+The full extensions array is returned by `mime.extensions()`. E.g.
+
+```js
+mime.extensions('text/x-some-format'); // => ['x-sf', 'x-sft', 'x-sfml']
 ```
 
 ### mime.load(filepath)

--- a/build/test.js
+++ b/build/test.js
@@ -22,7 +22,7 @@ assert.equal('application/octet-stream', mime.lookup('text.nope')); // unrecogni
 assert.equal('fallback', mime.lookup('text.fallback', 'fallback')); // alternate default
 
 //
-// Test extensions
+// Test extension
 //
 
 assert.equal('txt', mime.extension(mime.types.text));
@@ -36,6 +36,17 @@ assert.equal('html', mime.extension('text/html ; charset=UTF-8'));
 assert.equal('html', mime.extension('text/html;charset=UTF-8'));
 assert.equal('html', mime.extension('text/Html;charset=UTF-8'));
 assert.equal(undefined, mime.extension('unrecognized'));
+assert.equal('jpeg', mime.extension('image/jpeg'))
+
+//
+// Test extensions
+//
+
+assert.deepEqual(['html', 'htm'], mime.extensions('text/html'));
+assert.deepEqual(['bin','dms','lrf','mar','so','dist','distz','pkg','bpk','dump','elc','deploy','buffer'], mime.extensions('application/octet-stream'))
+assert.deepEqual(['jpeg','jpg','jpe'], mime.extensions('image/jpeg'))
+assert.deepEqual(['latex'], mime.extensions('application/x-latex'));
+assert.equal(undefined, mime.extensions('fake/mimetype'));
 
 //
 // Test node.types lookups

--- a/mime.js
+++ b/mime.js
@@ -6,7 +6,7 @@ function Mime() {
   this.types = Object.create(null);
 
   // Map of mime type -> extension
-  this.extensions = Object.create(null);
+  this.exts = Object.create(null);
 }
 
 /**
@@ -31,8 +31,8 @@ Mime.prototype.define = function (map) {
     }
 
     // Default extension is the first one we encounter
-    if (!this.extensions[type]) {
-      this.extensions[type] = exts[0];
+    if (!this.exts[type]) {
+      this.exts[type] = exts;
     }
   }
 };
@@ -72,12 +72,21 @@ Mime.prototype.lookup = function(path, fallback) {
   return this.types[ext] || fallback || this.default_type;
 };
 
+
 /**
- * Return file extension associated with a mime type
+ * Return file extensions associated with a mime type
+ */
+Mime.prototype.extensions = function(mimeType) {
+  var type = mimeType.match(/^\s*([^;\s]*)(?:;|\s|$)/)[1].toLowerCase();
+  return this.exts[type];
+};
+
+/**
+ * Return default file extension associated with a mime type
  */
 Mime.prototype.extension = function(mimeType) {
-  var type = mimeType.match(/^\s*([^;\s]*)(?:;|\s|$)/)[1].toLowerCase();
-  return this.extensions[type];
+  var extensions = this.extensions(mimeType);
+  return extensions && extensions[0];
 };
 
 // Default instance


### PR DESCRIPTION
### CHANGE SUMMARY

Update to provide new `extensions` method to expose full list of valid extensions for a mimetype.  Existing `extension` method semantics are unchanged, so this should be fully backward compatible.

Documentation and tests are updated to reflect these changes.
