### PR TITLE
Handle Case for S3 gzipped files

### DIFF
--- a/build/test.js
+++ b/build/test.js
@@ -20,6 +20,7 @@ assert.equal('text/plain', mime.lookup('/txt'));         // extension-less ()
 assert.equal('text/plain', mime.lookup('\\txt'));        // Windows, extension-less
 assert.equal('application/octet-stream', mime.lookup('text.nope')); // unrecognized
 assert.equal('fallback', mime.lookup('text.fallback', 'fallback')); // alternate default
+assert.equal('text/plain', mime.lookup('text.txt.gz'));  // gzipped file
 
 //
 // Test extensions

--- a/mime.js
+++ b/mime.js
@@ -67,6 +67,9 @@ Mime.prototype.load = function(file) {
  * Lookup a mime type based on extension
  */
 Mime.prototype.lookup = function(path, fallback) {
+  if (path.substring(path.length-3) == ".gz") {
+    path = path.substring(0, path.length-3);
+  }
   var ext = path.replace(/.*[\.\/\\]/, '').toLowerCase();
 
   return this.types[ext] || fallback || this.default_type;


### PR DESCRIPTION
My team was having issues with files that once sent to S3 had the `.gz` extension added to the end.
If we ignore the `.gz` extension then files like `file.css.gz` will be treated as a `.css` file and gain the correct mime type.

Would be great to see this merged if it doesn't break anything else. Thanks.
