### PR TITLE
Removing duplicate scripts property.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
     "url": "http://github.com/broofa",
     "email": "robert@broofa.com"
   },
-  "scripts": {
-    "test": "node test.js"
-  },
   "bin": {
     "mime": "cli.js"
   },


### PR DESCRIPTION
This duplicate property is causing problems for Node Tools for Visual Studio. It also appears to be incorrect as it is pointing to a file (test.js) that does not exist in that folder.