### PR TITLE
debug fix for #117

### DIFF
--- a/mime.js
+++ b/mime.js
@@ -22,9 +22,9 @@ Mime.prototype.define = function (map) {
   for (var type in map) {
     var exts = map[type];
     for (var i = 0; i < exts.length; i++) {
-      if (process.env.DEBUG_MIME && this.types[exts]) {
-        console.warn(this._loading.replace(/.*\//, ''), 'changes "' + exts[i] + '" extension type from ' +
-          this.types[exts] + ' to ' + type);
+      if (process.env.DEBUG_MIME && this.types[exts[i]]) {
+        console.warn((this._loading || "define()").replace(/.*\//, ''), 'changes "' + exts[i] + '" extension type from ' +
+          this.types[exts[i]] + ' to ' + type);
       }
 
       this.types[exts[i]] = type;


### PR DESCRIPTION
This fixes #117
`this._loading` is undefined/null if calling 'define()' directly, rather than via `load()`.
`exts` incorrectly being used in `this.types[exts]`. Since exts is an array, it only works if the array holds a single value.