### PR TITLE
add .json extension for webpack targeting node

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 
 const Mime = require('./Mime');
-module.exports = new Mime(require('./types/standard'), require('./types/other'));
+module.exports = new Mime(require('./types/standard.json'), require('./types/other.json'));


### PR DESCRIPTION
Superagent cannot be webpacked targeting node due to the missing .json extension.

```
ERROR in ./~/mime/index.js
Module not found: Error: Can't resolve './types/standard' in '/Users/user/project/node_modules/mime'
 @ ./~/mime/index.js 4:26-53
 @ ./~/superagent/lib/node/index.js
 @ ./src/lib/api.ts
 @ ./src/index.ts
 @ multi ./src/index.ts

ERROR in ./~/mime/index.js
Module not found: Error: Can't resolve './types/other' in '/Users/user/project/node_modules/mime'
 @ ./~/mime/index.js 4:55-79
 @ ./~/superagent/lib/node/index.js
 @ ./src/lib/api.ts
 @ ./src/index.ts
 @ multi ./src/index.ts
```

Adding `.json`, and using a json loader in webpack:

```
    {
      test: /\.json$/,
      loader: 'json-loader'
    }
```

resolves this issue.

Superagent needs to be webpacked with `target: node` outside of web environments.

https://github.com/visionmedia/superagent/wiki/Superagent-for-Webpack

Its possible there is a better way to resolve this in webpack.

