### PR TITLE
Bind exported methods

### DIFF
--- a/Mime.js
+++ b/Mime.js
@@ -11,6 +11,10 @@ function Mime() {
   for (var i = 0; i < arguments.length; i++) {
     this.define(arguments[i]);
   }
+
+  this.define = this.define.bind(this);
+  this.getType = this.getType.bind(this);
+  this.getExtension = this.getExtension.bind(this);
 }
 
 /**


### PR DESCRIPTION
So that code like below, which is an increasingly common style of importing, doesn't fail because `this` isn't bound to the right object.

```
const {getType} = require("mime");

getType("hello.txt");
```
