### PR TITLE
Remove unnecessary engines key.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
     "url": "http://github.com/broofa",
     "email": "robert@broofa.com"
   },
-  "engines": {
-    "node": ">=6.0.0"
-  },
   "bin": {
     "mime": "cli.js"
   },


### PR DESCRIPTION
Node 4 is still LTS for a little while longer and this isn't needed.
