### PR TITLE
convert to Map

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
     "browser": true,
     "commonjs": true,
     "node": true,
-    "mocha": true
+    "mocha": true,
+    "es6": true
   },
   "extends": ["eslint:recommended"],
   "rules": {

--- a/Mime.js
+++ b/Mime.js
@@ -5,8 +5,8 @@
  * @param ...
  */
 function Mime() {
-  this._types = Object.create(null);
-  this._extensions = Object.create(null);
+  this._types = new Map();
+  this._extensions = new Map();
 
   for (var i = 0; i < arguments.length; i++) {
     this.define(arguments[i]);
@@ -40,26 +40,26 @@ Mime.prototype.define = function(typeMap, force) {
 
       // '*' prefix = not the preferred type for this extension.  So fixup the
       // extension, and skip it.
-      if (ext[0] == '*') {
+      if (ext[0] === '*') {
         extensions[i] = ext.substr(1);
         continue;
       }
 
-      if (!force && (ext in this._types)) {
+      if (!force && this._types.has(ext)) {
         throw new Error(
           'Attempt to change mapping for "' + ext +
-          '" extension from "' + this._types[ext] + '" to "' + type +
+          '" extension from "' + this._types.get(ext) + '" to "' + type +
           '". Pass `force=true` to allow this, otherwise remove "' + ext +
           '" from the list of extensions for "' + type + '".'
         );
       }
 
-      this._types[ext] = type;
+      this._types.set(ext, type);
     }
 
     // Use first extension as default
-    if (force || !this._extensions[type]) {
-      this._extensions[type] = extensions[0];
+    if (force || !this._extensions.has(type)) {
+      this._extensions.set(type, extensions[0]);
     }
   }
 };
@@ -75,7 +75,7 @@ Mime.prototype.getType = function(path) {
   var hasPath = last.length < path.length;
   var hasDot = ext.length < last.length - 1;
 
-  return (hasDot || !hasPath) && this._types[ext] || null;
+  return (hasDot || !hasPath) && this._types.get(ext) || null;
 };
 
 /**
@@ -83,7 +83,7 @@ Mime.prototype.getType = function(path) {
  */
 Mime.prototype.getExtension = function(type) {
   type = /^\s*([^;\s]*)/.test(type) && RegExp.$1;
-  return type && this._extensions[type.toLowerCase()] || null;
+  return type && this._extensions.get(type.toLowerCase()) || null;
 };
 
 module.exports = Mime;

--- a/src/test.js
+++ b/src/test.js
@@ -5,6 +5,8 @@ var mimeTypes = require('../node_modules/mime-types');
 var assert = require('assert');
 var chalk = require('chalk');
 
+const typeMapEqual = (typeMap, obj) => assert.deepEqual([...typeMap], Object.entries(obj));
+
 describe('class Mime', function() {
   it('new constructor()', function() {
     var Mime = require('../Mime');
@@ -14,14 +16,14 @@ describe('class Mime', function() {
       {'text/b': ['b', 'b1']}
     );
 
-    assert.deepEqual(mime._types, {
+    typeMapEqual(mime._types, {
       a: 'text/a',
       a1: 'text/a',
       b: 'text/b',
       b1: 'text/b',
     });
 
-    assert.deepEqual(mime._extensions, {
+    typeMapEqual(mime._extensions, {
       'text/a': 'a',
       'text/b': 'b',
     });
@@ -40,12 +42,12 @@ describe('class Mime', function() {
       mime.define({'text/c': ['b']}, true);
     });
 
-    assert.deepEqual(mime._types, {
+    typeMapEqual(mime._types, {
       a: 'text/a',
       b: 'text/c',
     });
 
-    assert.deepEqual(mime._extensions, {
+    typeMapEqual(mime._extensions, {
       'text/a': 'a',
       'text/b': 'b',
       'text/c': 'b',
@@ -60,11 +62,11 @@ describe('class Mime', function() {
       {'text/b': ['b']}
     );
 
-    assert.deepEqual(mime._types, {
+    typeMapEqual(mime._types, {
       b: 'text/b',
     });
 
-    assert.deepEqual(mime._extensions, {
+    typeMapEqual(mime._extensions, {
       'text/a': 'b',
       'text/b': 'b',
     });
@@ -234,8 +236,8 @@ describe('DB', function() {
     assert.equal(mime.getExtension('text/html; charset=UTF-8'), 'html');
     assert.equal(mime.getExtension('text/html; charset=UTF-8 '), 'html');
     assert.equal(mime.getExtension('text/html ; charset=UTF-8'), 'html');
-    assert.equal(mime.getExtension(mime._types.text), 'txt');
-    assert.equal(mime.getExtension(mime._types.htm), 'html');
+    assert.equal(mime.getExtension(mime._types.get('text')), 'txt');
+    assert.equal(mime.getExtension(mime._types.get('htm')), 'html');
     assert.equal(mime.getExtension('application/octet-stream'), 'bin');
     assert.equal(mime.getExtension('application/octet-stream '), 'bin');
     assert.equal(mime.getExtension(' text/html; charset=UTF-8'), 'html');


### PR DESCRIPTION
Convert plain objects to Maps, which have faster insertion and access time

```js
let mime;

console.time('startup');
mime = require('..');
console.timeEnd('startup');

const types = require('../types/standard');
console.time('access');
for (let i=0; i<1000; i++) {
  const x1=mime.getExtension('audio/mpeg');
  const x2=mime.getType('fooo.mpeg');

  const x3=mime.getExtension('audio/mp3');
  const x4=mime.getType('fooo.mp3');
  for (let j=0; j<types.length; j++) {
    const xj = mime.getExtension(types[j])
  }
}
console.timeEnd('access');

/* with Objects.create(null):
startup: 3.599ms
access: 1.612ms
*/

/* with Map
startup: 3.268ms
access: 1.479ms
*/
```