### PR TITLE
fix: #192

### DIFF
--- a/Mime.js
+++ b/Mime.js
@@ -41,7 +41,6 @@ Mime.prototype.define = function(typeMap, force) {
       // '*' prefix = not the preferred type for this extension.  So fixup the
       // extension, and skip it.
       if (ext[0] == '*') {
-        extensions[i] = ext.substr(1);
         continue;
       }
 
@@ -59,7 +58,8 @@ Mime.prototype.define = function(typeMap, force) {
 
     // Use first extension as default
     if (force || !this._extensions[type]) {
-      this._extensions[type] = extensions[0];
+      var ext = extensions[0];
+      this._extensions[type] = (ext[0] != '*') ? ext : ext.substr(1)
     }
   }
 };

--- a/src/test.js
+++ b/src/test.js
@@ -6,6 +6,12 @@ var assert = require('assert');
 var chalk = require('chalk');
 
 describe('class Mime', function() {
+  it('mime and mime/lite coexist', function() {
+    assert.doesNotThrow(function() {
+      require('../lite');
+    });
+  });
+
   it('new constructor()', function() {
     var Mime = require('../Mime');
 


### PR DESCRIPTION
`Mime#define` was mutating its `typeMap` args, causing inconsistent (and throw-y) behavior if a map was used more than once.

This fixes that.