### PR TITLE
Add JSON extension to imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 
 var Mime = require('./Mime');
-module.exports = new Mime(require('./types/standard'), require('./types/other'));
+module.exports = new Mime(require('./types/standard.json'), require('./types/other.json'));


### PR DESCRIPTION
Fixes errors in Webpack build.

ERROR in ./node_modules/mime/index.js
Module build failed: Error: ENOENT: no such file or directory, open '.../node_modules/mime/index.js'