### PR TITLE
Specify json extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 
 var Mime = require('./Mime');
-module.exports = new Mime(require('./types/standard'), require('./types/other'));
+module.exports = new Mime(require('./types/standard.json'), require('./types/other.json'));

--- a/lite.js
+++ b/lite.js
@@ -1,4 +1,4 @@
 'use strict';
 
 var Mime = require('./Mime');
-module.exports = new Mime(require('./types/standard'));
+module.exports = new Mime(require('./types/standard.json'));


### PR DESCRIPTION
I've seen this issue appear here and there and it often looks like this:

```js
Error while initializing entrypoint: { Error: Cannot find module './types/standard'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/var/task/user/services/jira-webhooks/index.js:102080:18)
    at __webpack_require__ (/var/task/user/services/jira-webhooks/index.js:21:30)
    at Object.module.exports.Mime.define.extensions (/var/task/user/services/jira-webhooks/index.js:101977:27)
    at __webpack_require__ (/var/task/user/services/jira-webhooks/index.js:21:30)
    at Object.<anonymous> (/var/task/user/services/jira-webhooks/index.js:101254:12)
    at __webpack_require__ (/var/task/user/services/jira-webhooks/index.js:21:30) code: 'MODULE_NOT_FOUND' }
```

Basically the loader (in this case webpack) couldn't find `'./types/standard'` but specifying the extension makes it work.

Is there any specific reason for omitting it?