### PR TITLE
ESM support and typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,4 +187,4 @@ E.g.
     application/javascript
 
 ----
-Markdown generated from [src/README_js.md](src/README_js.md) by [![RunMD Logo](http://i.imgur.com/h0FVyzU.png)](https://github.com/broofa/runmd)
+Markdown generated from [src/README_js.md](src\README_js.md) by [![RunMD Logo](http://i.imgur.com/h0FVyzU.png)](https://github.com/broofa/runmd)

--- a/README.md
+++ b/README.md
@@ -187,4 +187,4 @@ E.g.
     application/javascript
 
 ----
-Markdown generated from [src/README_js.md](src\README_js.md) by [![RunMD Logo](http://i.imgur.com/h0FVyzU.png)](https://github.com/broofa/runmd)
+Markdown generated from [src/README_js.md](src/README_js.md) by [![RunMD Logo](http://i.imgur.com/h0FVyzU.png)](https://github.com/broofa/runmd)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+interface IDictionary<TValue> {
+    [id: string]: TValue;
+}
+
+declare class Mime {
+    constructor(...typeMaps: IDictionary<string[]>[]);
+
+    getType(extension: string): string | null;
+
+    getExtension(mimeType: string): string | null;
+}
+
+export const _default: Mime;
+export default _default;

--- a/index.es.js
+++ b/index.es.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var Mime = require('./Mime');
+
+exports._default = new Mime(require('./types/standard'), require('./types/other'));
+exports.default = exports._default;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mime",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,5 +40,6 @@
     "type": "git"
   },
   "version": "2.4.0",
+  "typings": "index.d.ts",
   "module": "index.es.js"
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,6 @@
     "url": "https://github.com/broofa/node-mime",
     "type": "git"
   },
-  "version": "2.4.0"
+  "version": "2.4.0",
+  "module": "index.es.js"
 }


### PR DESCRIPTION
* Added supportd of ES modules (Mime is exported as default) 6265b8313bdcbfef16e20b7c2e9ae7d3b02c8ef4  
This will allow to write 
  ```javascript
  import Mime from "node-mime";
  ```
  instead of 
  ```javascript
  import  *  as Mime from "node-mime";
  ```
* Added `index.d.ts` for TS users code assitance f8a836791c0eef9a5ac40b6af83376c44f73be64