### PR TITLE
Don't use arrow function introduced in 2.4.1

### DIFF
--- a/Mime.js
+++ b/Mime.js
@@ -38,7 +38,7 @@ function Mime() {
  */
 Mime.prototype.define = function(typeMap, force) {
   for (var type in typeMap) {
-    var extensions = typeMap[type].map(t => t.toLowerCase());
+    var extensions = typeMap[type].map(function(t) {return t.toLowerCase()});
     type = type.toLowerCase();
 
     for (var i = 0; i < extensions.length; i++) {


### PR DESCRIPTION
There is ES6 syntax introduced in the latest release 2.4.1. Meanwhile the whole package is written in ES5 (`var` instead of `const`, etc).

Introducing this tiny use of arrow function renders usage of this module in browsers like IE11 impossible.

I hope it's not a big deal to stick with older syntax to remain consistent with code style and browser/node support

See https://github.com/broofa/node-mime/issues/221#issuecomment-445076087

### If you have an issue with a specific extension or type

Locate the definition for your extension/type in the [db.json file](https://github.com/jshttp/mime-db/blob/master/db.json) in the `mime-db` project.  Does it look right?

- [ ] No. [File a `mime-db` issue](https://github.com/jshttp/mime-db/issues/new).
- [x] Yes: Go ahead and submit your issue/PR here and I'll look into it.
